### PR TITLE
Fix img path

### DIFF
--- a/declaration/1.0/JA/index.markdown
+++ b/declaration/1.0/JA/index.markdown
@@ -38,7 +38,7 @@ _今、この考え方を世界に広め、個人、社会、経済に及ぼす�
 
 _注：「**役割**」は「**（担当（者/組織）**」を意味するものではありません。個人または組織は一度に1つ以上の役割を担うことができます。_
 
-![MYDATAにおける役割](image_0_JA.png)
+![MYDATAにおける役割](https://github.com/MyDataJapan/documents/blob/master/declaration/1.0/JA/image_0_JA.png)
 
 ### 個人
 


### PR DESCRIPTION
https://mydatajapan.org/documents/declaration.html
の画像”MYDATAにおける役割” が相対パスのため表示されていませんでした。

<img width="1671" alt="スクリーンショット 2020-01-02 6 55 27" src="https://user-images.githubusercontent.com/7252645/71646532-72bd2c80-2d2d-11ea-9eb1-d260140fb947.png">

下記のように絶対パスに修正しました。

image_0_JA.png -> https://github.com/MyDataJapan/documents/blob/master/declaration/1.0/JA/image_0_JA.png